### PR TITLE
Add Jest tests for math utilities

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy:prod": "vercel --prod"
+    "deploy:prod": "vercel --prod",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -20,6 +21,9 @@
     "postcss": "^8.4.21",
     "tailwindcss": "^3.3.2",
     "typescript": "^5.0.4",
-    "vite": "^4.3.0"
+    "vite": "^4.3.0",
+    "jest": "^29.6.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.2"
   }
 }

--- a/src/engine/__tests__/Matrix3.test.ts
+++ b/src/engine/__tests__/Matrix3.test.ts
@@ -1,0 +1,23 @@
+import { Matrix3 } from '../Matrix3';
+
+function expectMatrixClose(actual: Matrix3, expected: Matrix3, precision = 5) {
+  actual.values.forEach((v, i) => {
+    expect(v).toBeCloseTo(expected.values[i], precision);
+  });
+}
+
+describe('Matrix3.invert', () => {
+  it('inverts a matrix and yields identity when multiplied', () => {
+    const m = Matrix3.translation(2, 3)
+      .multiply(Matrix3.rotation(Math.PI / 6))
+      .multiply(Matrix3.scale(2, 4));
+    const inv = m.invert();
+    const result = m.multiply(inv);
+    expectMatrixClose(result, Matrix3.identity());
+  });
+
+  it('throws on non invertible matrix', () => {
+    const m = Matrix3.scale(0, 1);
+    expect(() => m.invert()).toThrow('Matrix not invertible');
+  });
+});

--- a/src/engine/__tests__/Vec2D.test.ts
+++ b/src/engine/__tests__/Vec2D.test.ts
@@ -1,0 +1,16 @@
+import { Vec2D } from '../Vec2D';
+
+describe('Vec2D.fromPolar', () => {
+  it('creates vector at given length and angle', () => {
+    const v = Vec2D.fromPolar(5, Math.PI / 4);
+    const comp = 5 / Math.sqrt(2);
+    expect(v.x).toBeCloseTo(comp);
+    expect(v.y).toBeCloseTo(comp);
+  });
+
+  it('handles zero angle', () => {
+    const v = Vec2D.fromPolar(3, 0);
+    expect(v.x).toBeCloseTo(3);
+    expect(v.y).toBeCloseTo(0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "types": ["vite/client"],
+    "types": ["vite/client", "jest"],
     "module": "ESNext",
     "moduleResolution": "Node",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest
- configure TypeScript for Jest
- add unit tests for `Vec2D.fromPolar` and `Matrix3.invert`

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684024bebabc832e9702e750a3d1a465