### PR TITLE
Clarify turn limit comment

### DIFF
--- a/src/game/VehicleController.ts
+++ b/src/game/VehicleController.ts
@@ -73,7 +73,7 @@ export class VehicleController {
         const speed = this.body.velocity.length;
         if (speed <= 0.01) return;
 
-        // Ограничим максимум угла поворота за кадр
+        // Ограничим максимальный угол поворота в зависимости от пройденного расстояния
         const maxTurnPerMeter = 0.5; // радиан на 1 мировую единицу
         const distance = speed * dt;
         const maxRotation = maxTurnPerMeter * distance;


### PR DESCRIPTION
## Summary
- clarify that rotation limit depends on distance traveled, not frame rate

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684024bcce78832e881881ffa9a5a007