### PR TITLE
Improve keyboard controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy:prod": "vercel --prod"
+    "deploy:prod": "vercel --prod",
+    "test": "npx tsc src/game/controls/KeyboardControl.ts src/game/controls/Events.ts --module commonjs --outDir tests/dist --skipLibCheck && node tests/keyboardControl.test.js"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/game/controls/KeyboardControl.ts
+++ b/src/game/controls/KeyboardControl.ts
@@ -29,6 +29,15 @@ type Listener = (event: ControlEvent) => void;
 
 export class KeyboardControl {
     private listeners: Listener[] = [];
+    private pressed = {
+        Up: false,
+        Down: false,
+        Left: false,
+        Right: false,
+    };
+
+    private vertical = 0;
+    private horizontal = 0;
 
     constructor(private keycodes: KeyCodes) {}
 
@@ -45,34 +54,63 @@ export class KeyboardControl {
     }
 
     private keyDownListener = (e: KeyboardEvent) => {
+        let changed = false;
         switch (e.code) {
             case this.keycodes.Up:
-                this.emit({ type: 'vertical', value: 1 });
+                changed = !this.pressed.Up;
+                this.pressed.Up = true;
                 break;
             case this.keycodes.Down:
-                this.emit({ type: 'vertical', value: -1 });
+                changed = !this.pressed.Down;
+                this.pressed.Down = true;
                 break;
             case this.keycodes.Left:
-                this.emit({ type: 'horizontal', value: -1 });
+                changed = !this.pressed.Left;
+                this.pressed.Left = true;
                 break;
             case this.keycodes.Right:
-                this.emit({ type: 'horizontal', value: 1 });
+                changed = !this.pressed.Right;
+                this.pressed.Right = true;
                 break;
         }
+        if (changed) this.updateAxes();
     };
 
     private keyUpListener = (e: KeyboardEvent) => {
+        let changed = false;
         switch (e.code) {
             case this.keycodes.Up:
+                changed = this.pressed.Up;
+                this.pressed.Up = false;
+                break;
             case this.keycodes.Down:
-                this.emit({ type: 'vertical', value: 0 });
+                changed = this.pressed.Down;
+                this.pressed.Down = false;
                 break;
             case this.keycodes.Left:
+                changed = this.pressed.Left;
+                this.pressed.Left = false;
+                break;
             case this.keycodes.Right:
-                this.emit({ type: 'horizontal', value: 0 });
+                changed = this.pressed.Right;
+                this.pressed.Right = false;
                 break;
         }
+        if (changed) this.updateAxes();
     };
+
+    private updateAxes() {
+        const newVertical = (this.pressed.Up ? 1 : 0) + (this.pressed.Down ? -1 : 0);
+        const newHorizontal = (this.pressed.Right ? 1 : 0) + (this.pressed.Left ? -1 : 0);
+        if (newVertical !== this.vertical) {
+            this.vertical = newVertical;
+            this.emit({ type: 'vertical', value: this.vertical });
+        }
+        if (newHorizontal !== this.horizontal) {
+            this.horizontal = newHorizontal;
+            this.emit({ type: 'horizontal', value: this.horizontal });
+        }
+    }
 
     attach() {
         document.addEventListener('keydown', this.keyDownListener);

--- a/tests/keyboardControl.test.js
+++ b/tests/keyboardControl.test.js
@@ -1,0 +1,56 @@
+const assert = require('assert');
+const { KeyboardControl, KeyCodeWASD } = require('./dist/KeyboardControl');
+
+function press(ctrl, code) {
+    ctrl.keyDownListener({ code });
+}
+
+function release(ctrl, code) {
+    ctrl.keyUpListener({ code });
+}
+
+function collect(ctrl) {
+    const events = [];
+    ctrl.subscribe(e => events.push(e));
+    return events;
+}
+
+function testVertical() {
+    const ctrl = new KeyboardControl(KeyCodeWASD);
+    const events = collect(ctrl);
+    press(ctrl, KeyCodeWASD.Up);
+    press(ctrl, KeyCodeWASD.Down);
+    release(ctrl, KeyCodeWASD.Up);
+    release(ctrl, KeyCodeWASD.Down);
+    assert.deepStrictEqual(events, [
+        { type: 'vertical', value: 1 },
+        { type: 'vertical', value: 0 },
+        { type: 'vertical', value: -1 },
+        { type: 'vertical', value: 0 },
+    ]);
+}
+
+function testHorizontal() {
+    const ctrl = new KeyboardControl(KeyCodeWASD);
+    const events = collect(ctrl);
+    press(ctrl, KeyCodeWASD.Left);
+    press(ctrl, KeyCodeWASD.Right);
+    release(ctrl, KeyCodeWASD.Left);
+    release(ctrl, KeyCodeWASD.Right);
+    assert.deepStrictEqual(events, [
+        { type: 'horizontal', value: -1 },
+        { type: 'horizontal', value: 0 },
+        { type: 'horizontal', value: 1 },
+        { type: 'horizontal', value: 0 },
+    ]);
+}
+
+try {
+    testVertical();
+    testHorizontal();
+    console.log('Tests passed');
+} catch (err) {
+    console.error('Tests failed');
+    console.error(err);
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary
- track key press state in `KeyboardControl`
- compute axis values from pressed keys and emit only changes
- add a test script to verify combined key presses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684024b6cad8832eab5c27d5155a9f7a