### PR TITLE
Add pause menu toggle via Escape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ Maintains contact state between frames.
 Main game loop. Initializes objects, integrates physics, handles collisions, rendering and game state.
 **ENTRY POINT** for Codex understanding the system.
 Provides `resize(width, height)` to adjust canvas and viewport when the browser window size changes.
+Exposes `pause()`, `resume()` and `togglePause()` to control the simulation loop.
 
 #### `Block.ts`
 
@@ -129,7 +130,8 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 React component that creates the `Game` once and attaches it to a `<canvas>`
 element. Uses `useEffect` with an empty dependency list so the game is not
 restarted on prop changes. Handles window resizing and updates the game's
-viewport via `Game.resize()`.
+viewport via `Game.resize()`. Accepts a `paused` prop to pause or resume the
+game instance.
 
 #### `src/LayeredLayout.tsx`
 
@@ -142,10 +144,16 @@ the bottom-right corner.
 Transparent overlay used for React interface elements. Currently only displays
 a small debug label in the bottom-right corner.
 
+#### `src/PauseMenu.tsx`
+
+Simple overlay shown when the game is paused. Currently renders an empty box
+centered on the screen.
+
 #### `src/App.tsx`
 
 Root React component. Renders `LayeredLayout` which hosts the game and UI
-layers.
+layers. Handles `Escape` key to toggle the `PauseMenu` layer and passes the
+pause state to `GameCanvas`.
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,33 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import LayeredLayout from './LayeredLayout';
 import GameCanvas from './GameCanvas';
 import UiOverlay from './UiOverlay';
+import PauseMenu from './PauseMenu';
 
 const App: React.FC = () => {
-  return (
-    <LayeredLayout layers={[
-      <GameCanvas key="game" />, 
-      <UiOverlay key="ui" />,
-    ]} />
-  );
+  const [paused, setPaused] = useState(false);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.code === 'Escape') {
+        setPaused((p) => !p);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
+  const layers: React.ReactNode[] = [
+    <GameCanvas key="game" paused={paused} />,
+  ];
+  if (paused) {
+    layers.push(<PauseMenu key="pause" />);
+  }
+  layers.push(<UiOverlay key="ui" />);
+
+  return <LayeredLayout layers={layers} />;
 };
 
 export default App;

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -33,6 +33,7 @@ export class Game {
     private terrorist!: Terrorist;
     private terroristEyes!: TerroristEyesRenderable;
     private collisionDetector!: CollisionDetector;
+    private paused = false;
 
     constructor(canvas: HTMLCanvasElement) {
         this.canvas = canvas;
@@ -237,16 +238,20 @@ export class Game {
 
     public start() {
         const loop = () => {
-            this.integrator.update((dt) => {
-                if (!this.gameState.isPlaying()) return;
+            if (!this.paused) {
+                this.integrator.update((dt) => {
+                    if (!this.gameState.isPlaying()) return;
 
-                this.applyMutualGravity();
+                    this.applyMutualGravity();
 
-                this.car.update(dt);
-                this.terrorist.update(dt);
-                this.updateTerroristEyesReaction(dt);
-                this.checkVictoryOrDefeat();
-            });
+                    this.car.update(dt);
+                    this.terrorist.update(dt);
+                    this.updateTerroristEyesReaction(dt);
+                    this.checkVictoryOrDefeat();
+                });
+            } else {
+                this.integrator.reset();
+            }
 
             this.updateCamera();
             this.collisionDetector.detect();
@@ -262,6 +267,18 @@ export class Game {
         this.canvas.width = width;
         this.canvas.height = height;
         this.viewport.canvasSize.set(width, height);
+    }
+
+    public pause() {
+        this.paused = true;
+    }
+
+    public resume() {
+        this.paused = false;
+    }
+
+    public togglePause() {
+        this.paused = !this.paused;
     }
 
     private checkVictoryOrDefeat() {

--- a/src/GameCanvas.tsx
+++ b/src/GameCanvas.tsx
@@ -6,7 +6,11 @@ import { Game } from './Game';
  * across re-renders. Handles window resizing so the canvas
  * always matches the browser size in pixels.
  */
-export const GameCanvas: React.FC = () => {
+export interface GameCanvasProps {
+    paused: boolean;
+}
+
+export const GameCanvas: React.FC<GameCanvasProps> = ({ paused }) => {
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
     const gameRef = useRef<Game | null>(null);
 
@@ -40,6 +44,16 @@ export const GameCanvas: React.FC = () => {
             window.removeEventListener('resize', resize);
         };
     }, []);
+
+    useEffect(() => {
+        const game = gameRef.current;
+        if (!game) return;
+        if (paused) {
+            game.pause();
+        } else {
+            game.resume();
+        }
+    }, [paused]);
 
     return <canvas ref={canvasRef} />;
 };

--- a/src/PauseMenu.tsx
+++ b/src/PauseMenu.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+/**
+ * Empty pause menu container displayed when the game is paused.
+ * Currently does not contain any controls.
+ */
+const PauseMenu: React.FC = () => (
+    <div className="flex items-center justify-center w-full h-full bg-black bg-opacity-50">
+        <div className="w-64 h-40 bg-gray-800 bg-opacity-90 rounded" />
+    </div>
+);
+
+export default PauseMenu;


### PR DESCRIPTION
## Summary
- pause/resume `Game` with new methods
- allow pausing through `GameCanvas` prop
- manage escape key and pause layer in `App`
- implement empty `PauseMenu` layer
- document new modules and behavior in `AGENTS.md`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684efdb04dec832eb78e5aa794d18c63