### PR TITLE
Add basic routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,12 +177,26 @@ dialog and resume the game.
 Reusable button component for menu entries. Accepts an `isTop` flag to enable
 focus with the Tab key only for the top dialog.
 
-#### `src/App.tsx`
+#### `src/ui/App.tsx`
 
-Root React component. Renders `LayeredLayout` with the `GameCanvas` and wraps
-everything in `DialogProvider`. Pressing `Escape` opens the `PauseMenu` dialog
-when no dialogs are active. The provider closes the top dialog on `Escape` and
-the pause state is updated via the dialog's `onClose` callback.
+Top-level React component that configures routing via `react-router-dom`.
+Defines two routes:
+
+* `/` — renders `GameApp`
+* `/about` — renders `AboutPage`
+
+Uses `BrowserRouter` and `Routes` from `react-router-dom`.
+
+#### `src/ui/GameApp.tsx`
+
+Encapsulates the original game UI. Wraps `LayeredLayout` with `GameCanvas`
+inside `DialogProvider`. Handles the `Escape` key to open the `PauseMenu`
+dialog and toggles the paused state when dialogs are shown.
+
+#### `src/ui/AboutPage.tsx`
+
+Simple page containing a centered `<h1>` heading with the project title
+"The Drift".
 
 #### `src/ui/DialogManager.tsx`
 

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "homepage": "https://github.com/harnyk/the-drift",
   "dependencies": {
+    "@types/react-router-dom": "^5.3.3",
     "clsx": "^2.1.1",
     "focus-trap-react": "^11.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^7.6.2",
     "vercel": "^42.3.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@types/react-router-dom':
+        specifier: ^5.3.3
+        version: 5.3.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -20,6 +23,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^7.6.2
+        version: 7.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vercel:
         specifier: ^42.3.0
         version: 42.3.0(rollup@3.29.5)
@@ -586,6 +592,9 @@ packages:
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
+  '@types/history@4.7.11':
+    resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
+
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
@@ -611,6 +620,12 @@ packages:
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
       '@types/react': ^18.0.0
+
+  '@types/react-router-dom@5.3.3':
+    resolution: {integrity: sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==}
+
+  '@types/react-router@5.1.20':
+    resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
 
   '@types/react@18.3.23':
     resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
@@ -936,6 +951,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -1990,6 +2009,23 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.6.2:
+    resolution: {integrity: sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.6.2:
+    resolution: {integrity: sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -2061,6 +2097,9 @@ packages:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   setprototypeof@1.1.1:
     resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
@@ -3036,6 +3075,8 @@ snapshots:
     dependencies:
       '@types/node': 16.18.11
 
+  '@types/history@4.7.11': {}
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/istanbul-lib-report@3.0.3':
@@ -3059,6 +3100,17 @@ snapshots:
 
   '@types/react-dom@18.3.7(@types/react@18.3.23)':
     dependencies:
+      '@types/react': 18.3.23
+
+  '@types/react-router-dom@5.3.3':
+    dependencies:
+      '@types/history': 4.7.11
+      '@types/react': 18.3.23
+      '@types/react-router': 5.1.20
+
+  '@types/react-router@5.1.20':
+    dependencies:
+      '@types/history': 4.7.11
       '@types/react': 18.3.23
 
   '@types/react@18.3.23':
@@ -3474,6 +3526,8 @@ snapshots:
   convert-hrtime@3.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.0.2: {}
 
   create-jest@29.7.0(@types/node@16.18.11)(ts-node@10.9.1(@types/node@16.18.11)(typescript@5.8.3)):
     dependencies:
@@ -4592,6 +4646,20 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-router-dom@7.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 7.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-router@7.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      cookie: 1.0.2
+      react: 18.3.1
+      set-cookie-parser: 2.7.1
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4647,6 +4715,8 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.7.2: {}
+
+  set-cookie-parser@2.7.1: {}
 
   setprototypeof@1.1.1: {}
 

--- a/src/ui/AboutPage.tsx
+++ b/src/ui/AboutPage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const AboutPage: React.FC = () => (
+    <div className="flex items-center justify-center h-screen">
+        <h1 className="text-4xl">The Drift</h1>
+    </div>
+);
+
+export default AboutPage;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,44 +1,15 @@
-import React, { useEffect, useState } from 'react';
-import LayeredLayout from './LayeredLayout';
-import GameCanvas from './GameCanvas';
-import PauseMenu from './PauseMenu';
-import { DialogProvider, useDialogManager } from './DialogManager';
-
-const InnerApp: React.FC = () => {
-    const [paused, setPaused] = useState(false);
-    const { hasDialog, showDialog, closeDialog } = useDialogManager();
-
-    useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (e.code === 'Escape' && !hasDialog) {
-                setPaused(true);
-                showDialog(
-                    (id, isTop) => (
-                        <PauseMenu
-                            dialogId={id}
-                            isTop={isTop}
-                            onExit={() => closeDialog(id)}
-                        />
-                    ),
-                    () => setPaused(false)
-                );
-            }
-        };
-        window.addEventListener('keydown', onKeyDown);
-        return () => {
-            window.removeEventListener('keydown', onKeyDown);
-        };
-    }, [hasDialog, showDialog, closeDialog]);
-
-    return (
-        <LayeredLayout layers={[<GameCanvas key="game" paused={paused} />]} />
-    );
-};
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import GameApp from './GameApp';
+import AboutPage from './AboutPage';
 
 const App: React.FC = () => (
-    <DialogProvider>
-        <InnerApp />
-    </DialogProvider>
+    <BrowserRouter>
+        <Routes>
+            <Route path="/" element={<GameApp />} />
+            <Route path="/about" element={<AboutPage />} />
+        </Routes>
+    </BrowserRouter>
 );
 
 export default App;

--- a/src/ui/GameApp.tsx
+++ b/src/ui/GameApp.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import LayeredLayout from './LayeredLayout';
+import GameCanvas from './GameCanvas';
+import PauseMenu from './PauseMenu';
+import { DialogProvider, useDialogManager } from './DialogManager';
+
+const InnerGame: React.FC = () => {
+    const [paused, setPaused] = useState(false);
+    const { hasDialog, showDialog, closeDialog } = useDialogManager();
+
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.code === 'Escape' && !hasDialog) {
+                setPaused(true);
+                showDialog(
+                    (id, isTop) => (
+                        <PauseMenu
+                            dialogId={id}
+                            isTop={isTop}
+                            onExit={() => closeDialog(id)}
+                        />
+                    ),
+                    () => setPaused(false)
+                );
+            }
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => {
+            window.removeEventListener('keydown', onKeyDown);
+        };
+    }, [hasDialog, showDialog, closeDialog]);
+
+    return <LayeredLayout layers={[<GameCanvas key="game" paused={paused} />]} />;
+};
+
+const GameApp: React.FC = () => (
+    <DialogProvider>
+        <InnerGame />
+    </DialogProvider>
+);
+
+export default GameApp;


### PR DESCRIPTION
## Summary
- integrate `react-router-dom`
- route `/` to the game UI
- route `/about` to a blank page
- document new modules in AGENTS

## Testing
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6853bdceca54832e996b0adaa4206533